### PR TITLE
Add event-driven telemetry handling with OpenAI integration

### DIFF
--- a/src/race_mcp_server/event_handler.py
+++ b/src/race_mcp_server/event_handler.py
@@ -1,0 +1,78 @@
+"""Event handling for telemetry and driver interactions."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any, Dict, Optional
+
+from .openai_client import OpenAIClient
+
+
+class MCPEventHandler:
+    """Process telemetry events and driver messages, calling OpenAI when needed."""
+
+    def __init__(self, openai_client: OpenAIClient):
+        self.openai_client = openai_client
+        self.telemetry_queue: "asyncio.Queue[Dict[str, Any]]" = asyncio.Queue()
+        self.last_flag_state = "Green"
+        self._task: Optional[asyncio.Task[None]] = None
+        self._running = False
+
+    async def start(self) -> None:
+        if not self._task:
+            self._running = True
+            self._task = asyncio.create_task(self._process_telemetry())
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(Exception):
+                await self._task
+            self._task = None
+
+    async def on_telemetry(self, telemetry: Dict[str, Any]) -> None:
+        await self.telemetry_queue.put(telemetry)
+
+    async def handle_user_message(self, message: str) -> str:
+        messages = [
+            {"role": "system", "content": "You are a helpful racing coach."},
+            {"role": "user", "content": message},
+        ]
+        response = await self.openai_client.chat(messages)
+        return response.get("content", "")
+
+    async def _process_telemetry(self) -> None:
+        while self._running:
+            telemetry = await self.telemetry_queue.get()
+            try:
+                await self._evaluate_telemetry(telemetry)
+            except Exception as exc:  # noqa: BLE001
+                logging.error("Telemetry processing error: %s", exc)
+
+    async def _evaluate_telemetry(self, telemetry: Dict[str, Any]) -> None:
+        flag_state = telemetry.get("flag_state", "Green")
+        if flag_state != self.last_flag_state:
+            self.last_flag_state = flag_state
+            messages = [
+                {"role": "system", "content": "You are a professional racing spotter."},
+                {
+                    "role": "user",
+                    "content": f"Flag changed to {flag_state}. Offer concise advice.",
+                },
+            ]
+            response = await self.openai_client.chat(messages)
+            logging.info("Flag change advice: %s", response.get("content", ""))
+
+        if not telemetry.get("is_on_track", True):
+            messages = [
+                {"role": "system", "content": "You are a racing coach."},
+                {
+                    "role": "user",
+                    "content": "Driver off track, give recovery tips.",
+                },
+            ]
+            response = await self.openai_client.chat(messages)
+            logging.info("Off-track advice: %s", response.get("content", ""))

--- a/src/race_mcp_server/openai_client.py
+++ b/src/race_mcp_server/openai_client.py
@@ -1,0 +1,50 @@
+"""OpenAI API wrapper with graceful fallback."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - import error handling
+    from openai import AsyncOpenAI
+
+    OPENAI_AVAILABLE = True
+except Exception:  # noqa: BLE001
+    OPENAI_AVAILABLE = False
+    AsyncOpenAI = None  # type: ignore[assignment]
+    logging.warning("OpenAI package not available; using stub responses")
+
+
+class OpenAIClient:
+    """Simple async wrapper around the OpenAI chat API."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o-mini"):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.model = model
+        self.client: Optional[AsyncOpenAI] = None
+        if OPENAI_AVAILABLE and self.api_key:
+            try:
+                self.client = AsyncOpenAI(api_key=self.api_key)
+            except Exception as exc:  # noqa: BLE001
+                logging.error("Failed to init OpenAI client: %s", exc)
+                self.client = None
+
+    async def chat(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+        """Send chat messages to the OpenAI API.
+
+        Returns a dictionary with ``role`` and ``content`` keys. If the OpenAI
+        client is unavailable, a stub response is returned.
+        """
+
+        if not self.client:
+            return {"role": "assistant", "content": "OpenAI not configured."}
+        try:
+            response = await self.client.chat.completions.create(
+                model=self.model, messages=messages
+            )
+            message = response.choices[0].message
+            return {"role": message.role, "content": message.content or ""}
+        except Exception as exc:  # noqa: BLE001
+            logging.error("OpenAI request failed: %s", exc)
+            return {"role": "assistant", "content": "Error contacting OpenAI."}

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -1,0 +1,12 @@
+import pytest
+
+from race_mcp_server.event_handler import MCPEventHandler
+from race_mcp_server.openai_client import OpenAIClient
+
+
+@pytest.mark.asyncio
+async def test_handle_user_message_returns_string():
+    client = OpenAIClient(api_key=None)
+    handler = MCPEventHandler(client)
+    response = await handler.handle_user_message("Hello coach")
+    assert isinstance(response, str)


### PR DESCRIPTION
## Summary
- add `OpenAIClient` wrapper that gracefully degrades when API isn't configured
- introduce `MCPEventHandler` to process telemetry and driver messages
- stream telemetry continuously and expose `send_driver_message` tool
- provide basic unit test for event handler messaging

## Testing
- `PYTHONPATH=src pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68be3452cc4c833087d10ad5c03e3b42