### PR TITLE
Add voice input/output utilities with OpenAI audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,30 @@ python test_client.py
 ./start_server.sh --test
 ```
 
+### 🎙 Voice Interaction
+
+Real-time voice communication is supported through optional audio utilities.
+
+#### Prerequisites
+- OpenAI API key set in ``OPENAI_API_KEY``
+- Install voice dependencies: ``pip install race-mcp-server[voice]``
+
+#### Example Usage
+```python
+import asyncio
+from race_mcp_server.openai_client import OpenAIClient
+from race_mcp_server.voice_interface import VoiceInterface
+
+async def main():
+    client = OpenAIClient()
+    voice = VoiceInterface(client)
+    await voice.chat_once()
+
+asyncio.run(main())
+```
+This records a short microphone clip, sends it to OpenAI for transcription and
+speaks the model's response back to the user.
+
 ## 🛠 Available Tools
 
 ### 1. `get_telemetry`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "aiofiles>=24.0.0",
     "anyio>=4.0.0",
+    "openai>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -28,6 +29,9 @@ dev = [
     "black>=24.0.0",
     "isort>=5.0.0",
     "mypy>=1.8.0",
+]
+voice = [
+    "sounddevice>=0.4.6",
 ]
 
 [project.scripts]

--- a/src/race_mcp_server/openai_client.py
+++ b/src/race_mcp_server/openai_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any, Dict, List, Optional
+from io import BytesIO
 
 try:  # pragma: no cover - import error handling
     from openai import AsyncOpenAI
@@ -48,3 +49,53 @@ class OpenAIClient:
         except Exception as exc:  # noqa: BLE001
             logging.error("OpenAI request failed: %s", exc)
             return {"role": "assistant", "content": "Error contacting OpenAI."}
+
+    async def transcribe_audio(
+        self, audio: bytes, model: str = "gpt-4o-mini-transcribe"
+    ) -> str:
+        """Transcribe audio bytes to text using OpenAI's transcription API.
+
+        Returns the transcribed text. If the OpenAI client is unavailable or the
+        request fails, an empty string is returned instead.
+        """
+
+        if not self.client:
+            return ""
+        try:
+            audio_file = BytesIO(audio)
+            response = await self.client.audio.transcriptions.create(
+                model=model, file=audio_file
+            )
+            return getattr(response, "text", "")
+        except Exception as exc:  # noqa: BLE001
+            logging.error("OpenAI transcription failed: %s", exc)
+            return ""
+
+    async def text_to_speech(
+        self,
+        text: str,
+        voice: str = "alloy",
+        model: str = "gpt-4o-mini-tts",
+        format: str = "mp3",
+    ) -> bytes:
+        """Convert text to speech and return audio bytes.
+
+        If the OpenAI client is unavailable or the request fails, an empty byte
+        string is returned.
+        """
+
+        if not self.client:
+            return b""
+        try:
+            response = await self.client.audio.speech.create(
+                model=model, voice=voice, input=text, format=format
+            )
+            # HttpxBinaryResponseContent provides an async read method
+            if hasattr(response, "aread"):
+                return await response.aread()
+            if hasattr(response, "read"):
+                return response.read()
+            return b""
+        except Exception as exc:  # noqa: BLE001
+            logging.error("OpenAI text-to-speech failed: %s", exc)
+            return b""

--- a/src/race_mcp_server/voice_interface.py
+++ b/src/race_mcp_server/voice_interface.py
@@ -1,0 +1,76 @@
+"""Utilities for real-time voice input and output."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from .openai_client import OpenAIClient
+
+try:  # pragma: no cover - optional dependency
+    import sounddevice as sd
+    import numpy as np
+
+    SOUNDDEVICE_AVAILABLE = True
+except Exception:  # noqa: BLE001
+    sd = None  # type: ignore[assignment]
+    np = None  # type: ignore[assignment]
+    SOUNDDEVICE_AVAILABLE = False
+    logging.warning("sounddevice not available; voice features disabled")
+
+
+class VoiceInterface:
+    """Interface for capturing microphone input and playing voice responses."""
+
+    def __init__(self, client: OpenAIClient, sample_rate: int = 16000):
+        self.client = client
+        self.sample_rate = sample_rate
+
+    async def record(self, duration: float = 3.0) -> Optional[bytes]:
+        """Record audio from the default microphone.
+
+        Returns raw PCM bytes or ``None`` if recording is unavailable.
+        """
+
+        if not SOUNDDEVICE_AVAILABLE:
+            logging.error("sounddevice is required for recording audio")
+            return None
+        loop = asyncio.get_event_loop()
+        audio = await loop.run_in_executor(
+            None,
+            lambda: sd.rec(
+                int(duration * self.sample_rate),
+                samplerate=self.sample_rate,
+                channels=1,
+                dtype="int16",
+            ),
+        )
+        await loop.run_in_executor(None, sd.wait)
+        return audio.tobytes()
+
+    async def play(self, audio: bytes) -> None:
+        """Play raw PCM audio bytes through the default output device."""
+
+        if not SOUNDDEVICE_AVAILABLE:
+            logging.error("sounddevice is required for audio playback")
+            return
+        if not audio:
+            return
+        loop = asyncio.get_event_loop()
+        samples = np.frombuffer(audio, dtype="int16")
+        await loop.run_in_executor(None, lambda: sd.play(samples, self.sample_rate))
+        await loop.run_in_executor(None, sd.wait)
+
+    async def chat_once(self, duration: float = 3.0) -> str:
+        """Capture voice input, send to OpenAI, speak the response, and return it."""
+
+        audio = await self.record(duration)
+        if not audio:
+            return ""
+        transcript = await self.client.transcribe_audio(audio)
+        if not transcript:
+            return ""
+        response = await self.client.chat([{"role": "user", "content": transcript}])
+        await self.play(await self.client.text_to_speech(response.get("content", "")))
+        return response.get("content", "")

--- a/test_client.py
+++ b/test_client.py
@@ -8,10 +8,13 @@ This script demonstrates how to connect to and interact with the Race MCP Server
 import asyncio
 import json
 import sys
+
+import pytest
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
 
+@pytest.mark.asyncio
 async def test_race_mcp_server():
     """Test the Race MCP Server functionality"""
     print("🏁 Testing Race MCP Server...")

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,17 @@
+import pytest
+
+from race_mcp_server.openai_client import OpenAIClient
+
+
+@pytest.mark.asyncio
+async def test_transcribe_audio_returns_string_without_openai():
+    client = OpenAIClient(api_key=None)
+    result = await client.transcribe_audio(b"fake")
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_text_to_speech_returns_bytes_without_openai():
+    client = OpenAIClient(api_key=None)
+    audio = await client.text_to_speech("hello")
+    assert isinstance(audio, bytes)


### PR DESCRIPTION
## Summary
- extend `OpenAIClient` with audio transcription and text-to-speech helpers
- add optional `VoiceInterface` for real-time microphone capture and playback
- document voice usage and include OpenAI/voice dependencies
- provide async test coverage for audio helpers

## Testing
- `pip install -e .[dev]`
- `pytest`
- `python test_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68be385082488330a124c105fc10d6ea