### PR TITLE
Add voice input event handling

### DIFF
--- a/src/race_mcp_server/event_handler.py
+++ b/src/race_mcp_server/event_handler.py
@@ -16,25 +16,35 @@ class MCPEventHandler:
     def __init__(self, openai_client: OpenAIClient):
         self.openai_client = openai_client
         self.telemetry_queue: "asyncio.Queue[Dict[str, Any]]" = asyncio.Queue()
+        self.voice_queue: "asyncio.Queue[bytes]" = asyncio.Queue()
         self.last_flag_state = "Green"
-        self._task: Optional[asyncio.Task[None]] = None
+        self._telemetry_task: Optional[asyncio.Task[None]] = None
+        self._voice_task: Optional[asyncio.Task[None]] = None
         self._running = False
 
     async def start(self) -> None:
-        if not self._task:
+        if not self._telemetry_task:
             self._running = True
-            self._task = asyncio.create_task(self._process_telemetry())
+            self._telemetry_task = asyncio.create_task(self._process_telemetry())
+        if not self._voice_task:
+            self._voice_task = asyncio.create_task(self._process_voice())
 
     async def stop(self) -> None:
         self._running = False
-        if self._task:
-            self._task.cancel()
-            with contextlib.suppress(Exception):
-                await self._task
-            self._task = None
+        for task_name in ("_telemetry_task", "_voice_task"):
+            task = getattr(self, task_name)
+            if task:
+                task.cancel()
+                with contextlib.suppress(Exception):
+                    await task
+                setattr(self, task_name, None)
 
     async def on_telemetry(self, telemetry: Dict[str, Any]) -> None:
         await self.telemetry_queue.put(telemetry)
+
+    async def on_voice_input(self, audio: bytes) -> None:
+        """Queue raw audio bytes for processing."""
+        await self.voice_queue.put(audio)
 
     async def handle_user_message(self, message: str) -> str:
         messages = [
@@ -44,6 +54,13 @@ class MCPEventHandler:
         response = await self.openai_client.chat(messages)
         return response.get("content", "")
 
+    async def handle_voice_input(self, audio: bytes) -> str:
+        """Transcribe audio and handle it as a user message."""
+        transcript = await self.openai_client.transcribe_audio(audio)
+        if not transcript:
+            return ""
+        return await self.handle_user_message(transcript)
+
     async def _process_telemetry(self) -> None:
         while self._running:
             telemetry = await self.telemetry_queue.get()
@@ -51,6 +68,16 @@ class MCPEventHandler:
                 await self._evaluate_telemetry(telemetry)
             except Exception as exc:  # noqa: BLE001
                 logging.error("Telemetry processing error: %s", exc)
+
+    async def _process_voice(self) -> None:
+        while self._running:
+            audio = await self.voice_queue.get()
+            try:
+                response = await self.handle_voice_input(audio)
+                if response:
+                    logging.info("Voice response: %s", response)
+            except Exception as exc:  # noqa: BLE001
+                logging.error("Voice processing error: %s", exc)
 
     async def _evaluate_telemetry(self, telemetry: Dict[str, Any]) -> None:
         flag_state = telemetry.get("flag_state", "Green")

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -10,3 +10,21 @@ async def test_handle_user_message_returns_string():
     handler = MCPEventHandler(client)
     response = await handler.handle_user_message("Hello coach")
     assert isinstance(response, str)
+
+
+@pytest.mark.asyncio
+async def test_handle_voice_input_uses_transcription(monkeypatch):
+    client = OpenAIClient(api_key=None)
+    handler = MCPEventHandler(client)
+
+    async def fake_transcribe(audio: bytes, model: str = "gpt-4o-mini-transcribe") -> str:
+        return "Voice message"
+
+    async def fake_chat(messages):
+        return {"role": "assistant", "content": "ack"}
+
+    monkeypatch.setattr(client, "transcribe_audio", fake_transcribe)
+    monkeypatch.setattr(client, "chat", fake_chat)
+
+    result = await handler.handle_voice_input(b"audio")
+    assert result == "ack"


### PR DESCRIPTION
## Summary
- add voice queue and processing to event handler for voice input recognition
- support transcribing audio and routing to chat responses
- cover voice input behavior with new unit test

## Testing
- `python -m black src/race_mcp_server/event_handler.py tests/test_event_handler.py`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be4729bab0833083d49a472daeea5f